### PR TITLE
Don't consider ldconfig map when picking libraries output by nvidia-container-cli as these should by definition be correct out of the box

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
     - Amanda Duffy <aduffy@lenovo.com>
     - Ana Guerrero Lopez <aguerrero@suse.com>
     - Ángel Bejarano <abejarano@ontropos.com>
+    - Aron Öfjörð Jóhannesson <aron1991@gmail.com>
     - Bernard Li <bernardli@lbl.gov>
     - Brian Bockelman <bbockelm@cse.unl.edu>
     - Carl Madison <carl@sylabs.io>

--- a/pkg/util/gpu/paths.go
+++ b/pkg/util/gpu/paths.go
@@ -44,13 +44,12 @@ func nvidiaContainerCli(args ...string) ([]string, error) {
 		}
 
 		if strings.Contains(line, ".so") {
-			// this is a library -> add library name
-			lib := filepath.Base(line)
-			libs = append(libs, lib)
+			// this is a library -> add full path to library
+			libs = append(libs, line)
 
-			// also add library without .xxx.xx suffix
-			bareLib := strings.SplitAfter(lib, ".so")[0]
-			libs = append(libs, bareLib)
+			// also add full path to library without .xxx.xx suffix
+			bareLibPath := strings.SplitAfter(line, ".so")[0]
+			libs = append(libs, bareLibPAth)
 		} else {
 			// this is a binary -> need full path
 			libs = append(libs, line)
@@ -178,24 +177,43 @@ func paths(gpuFileList []string) ([]string, []string, error) {
 	for _, file := range gpuFileList {
 		// if the file contains a ".so", treat it as a library
 		if strings.Contains(file, ".so") {
-			for libPath, libName := range ldCache {
-				if !strings.HasPrefix(libName, file) {
+			// if library path is absolute, it will have been returned by the container cli, which is more
+			// accurate than ldconfig when more than one drivers are found with same basename (e.g.
+			// /usr/lib64/libnvidia-tls.so and /usr/lib64/tls/libnvidia-tls.so)
+			if filepath.IsAbs(file) {
+				elib, err := elf.Open(file)
+				if err != nil {
+					sylog.Debugf("ignore library %s: %s", file, err)
 					continue
 				}
-				if _, ok := libs[libName]; !ok {
-					elib, err := elf.Open(libPath)
-					if err != nil {
-						sylog.Debugf("ignore library %s: %s", libName, err)
+
+				if elib.Machine == machine {
+					libraries = append(libraries, file)
+				}
+
+				if err := elib.Close(); err != nil {
+					sylog.Warningf("Could not close ELIB: %v", err)
+				}
+			} else {
+				for libPath, libName := range ldCache {
+					if !strings.HasPrefix(libName, file) {
 						continue
 					}
+					if _, ok := libs[libName]; !ok {
+						elib, err := elf.Open(libPath)
+						if err != nil {
+							sylog.Debugf("ignore library %s: %s", libName, err)
+							continue
+						}
 
-					if elib.Machine == machine {
-						libs[libName] = struct{}{}
-						libraries = append(libraries, libPath)
-					}
+						if elib.Machine == machine {
+							libs[libName] = struct{}{}
+							libraries = append(libraries, libPath)
+						}
 
-					if err := elib.Close(); err != nil {
-						sylog.Warningf("Could not close ELIB: %v", err)
+						if err := elib.Close(); err != nil {
+							sylog.Warningf("Could not close ELIB: %v", err)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Libraries returned by nvidia-container-cli always point (full path) to the correct drivers.
Therefore it should be completely unnecessary to try and match the driver basename to what has been cached by ldconfig, and instead it should be fine to just go straight for the driver returned by the container-cli

By avoiding the ld cache, this approach can fix an issue with a platform containing multiple active drivers with the same name, for example two implementations of the nvidia-tls drivers, one in /usr/lib64/libnvidia-tls.so and another in /usr/lib64/tls/libnvidia-tls.so

Needlessly leaving it to the ldcache (which is stored as an unordered map in runtime) will result in indeterminate selection of conflicting drivers, leading to inconsistent behaviour or even launch-time segfaults (in the event of the conflicting drivers being simply down to anomalous platform configuration) of gpu-driven applications 

### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

